### PR TITLE
Don't generate ID attribute in Mirage Factory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 master
 ------
 
+* Don't generate an "id" attribute in Mirage Factory. Mirage is responsible for
+  that
+
 0.0.3
 -----
 

--- a/addon/mirage/factory.js
+++ b/addon/mirage/factory.js
@@ -27,7 +27,7 @@ export default class Factory {
       if (Ember.isArray(property.type)) {
         const [firstType] = property.type;
         attrs[key] = generateValue(firstType, key);
-      } else {
+      } else if (key !== 'id') {
         attrs[key] = generateValue(property.type, key);
       }
     });

--- a/tests/unit/utils/factory-test.js
+++ b/tests/unit/utils/factory-test.js
@@ -1,0 +1,17 @@
+import { module, test } from 'qunit';
+import JsonSchemaFactory from 'ember-json-schema/mirage/factory';
+
+module('Factory');
+
+test('generate', assert => {
+  const schema = {
+    type: 'object',
+    properties: {
+      id: { type: 'string' },
+    },
+  };
+
+  const attrs = JsonSchemaFactory.generate(schema);
+
+  assert.ok(!attrs.id, 'does not generate id attribute');
+});


### PR DESCRIPTION
Mirage will ensure that IDs are the proper type (String), unique, and
increasing.
