### PR TITLE
Gracefully handle `$ref` key replacing `type` key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 master
 ------
 
+* Gracefully handle `$ref` key (instead of `type` key)
+
 0.0.4
 -----
 

--- a/addon/mirage/factory.js
+++ b/addon/mirage/factory.js
@@ -13,6 +13,8 @@ function generateValue(type, key) {
     return {};
   } else if (type === 'array') {
     return [];
+  } else {
+    return null;
   }
 }
 

--- a/addon/model.js
+++ b/addon/model.js
@@ -8,7 +8,9 @@ function cleanKey(key) {
 }
 
 function buildProperty(key, name, type) {
-  if (type.match(/string|number|boolean|date/i)) {
+  if (!type) {
+    return [name, DS.attr()];
+  } else if (type.match(/string|number|boolean|date/i)) {
     if (key.match(/_id$/)) {
       return [name, DS.belongsTo({ async: true })];
     } else {

--- a/tests/dummy/app/schemas/post.js
+++ b/tests/dummy/app/schemas/post.js
@@ -11,6 +11,7 @@ export default {
     },
     hash: { type: 'object' },
     metadata: { type: ['object', 'null'] },
+    other: { '$ref': 'other.json' },
     user_id: { type: 'number' },
     topic_ids: {
       type: 'array',

--- a/tests/unit/models/post-test.js
+++ b/tests/unit/models/post-test.js
@@ -79,4 +79,11 @@ test('attrs', function(assert) {
   assert.equal(hash.type, null, 'generates generic attribute');
 
   assert.deepEqual(get(model, 'hash'), {}, 'defaults to empty object');
+
+  const other = attrs.get('other');
+
+  assert.equal(other.name, 'other', 'generates generic attribute');
+  assert.equal(other.type, null, 'generates generic attribute');
+
+  assert.ok(!get(model, 'other'), 'defaults to generic object');
 });

--- a/tests/unit/utils/factory-test.js
+++ b/tests/unit/utils/factory-test.js
@@ -8,10 +8,13 @@ test('generate', assert => {
     type: 'object',
     properties: {
       id: { type: 'string' },
+      other: { '$ref': 'other.json' },
     },
   };
 
   const attrs = JsonSchemaFactory.generate(schema);
 
   assert.ok(!attrs.id, 'does not generate id attribute');
+  assert.ok(!attrs.other, 'generates null from $ref');
+  assert.equal(typeof attrs.other, 'object', 'generates property from $ref');
 });


### PR DESCRIPTION
When a property's `$ref` key is provided in place of `type`, we must
handle it gracefully.

When generating a model that references another schema (via `$ref`), we
add a generic `DS.attr()` property.

When generating a factory that references another schema (via `$ref`),
we create a `null` value.
